### PR TITLE
Bugfix/mailcollector tag replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # YAGP GLPI Plugin CHANGELOG
 
+## 2.2.2 - 2024-01-03
+### Bugfixes
+- Fix requester replacement for mailcollector #19272
+
 ## 2.2.1 - 2023-10-18
 ### Bugfixes
 - Fix transfer option ajax form

--- a/inc/postshowitem.class.php
+++ b/inc/postshowitem.class.php
@@ -130,8 +130,8 @@ JAVASCRIPT;
                     $icon = "<i class='fa-fw fas fa-level-up-alt'></i>";
                     $btn_attrs = "class='btn col-auto col-xxl-12' data-bs-toggle='modal'";
 
-                    $append = "<label class='col-form-label col-xxl-5 text-xxl-end'></label>";
-                    $append .= "<div class='col-xxl-7 row m-0 field-container'>";
+                    $append = "<label class='col-form-label col-xxl-4 text-xxl-end'></label>";
+                    $append .= "<div class='col-xxl-8 row m-0 field-container'>";
                     $append .= "<a {$btn_attrs} data-bs-target='#{$ajax_id}'";
                     $append .= "data-toggle='tooltip' title='{$entity_name}' href='#'>";
                     $append .= $icon . "<span class='text-truncate'>$ajax_title</span>";

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -117,11 +117,14 @@ class PluginYagpTicket extends CommonDBTM
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
-
-    public static function postItemForm($params = [])
+    /**
+     * postItemForm
+     *
+     * @param  mixed $params
+     * @return void
+     */
+    public static function postItemForm($params = []): void
     {
-        global $DB;
-
         $item = $params['item'];
         if (!is_array($item) && $item->getType() == Ticket::getType()) {
             $date = ($item->getID()) ? $item->fields['date'] : '';
@@ -137,7 +140,13 @@ JAVASCRIPT;
         }
     }
 
-    public static function preAddTicket(Ticket $ticket)
+    /**
+     * preAddTicket
+     *
+     * @param  mixed $ticket
+     * @return Ticket
+     */
+    public static function preAddTicket(Ticket $ticket): Ticket
     {
         $config = PluginYagpConfig::getConfig();
         $pattern = "/" . $config->fields['requestlabel'] . ".*" . $config->fields['requestlabel'] . "/i";
@@ -212,7 +221,13 @@ JAVASCRIPT;
         }
     }
 
-    public static function ticketRecategorization($ticket)
+    /**
+     * ticketRecategorization
+     *
+     * @param  mixed $ticket
+     * @return void
+     */
+    public static function ticketRecategorization($ticket): void
     {
         if (isset($ticket->oldvalues["itilcategories_id"])) {
             $ticket_cat = new self();

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -139,8 +139,6 @@ JAVASCRIPT;
 
     public static function preAddTicket(Ticket $ticket)
     {
-        global $DB;
-
         $config = PluginYagpConfig::getConfig();
         $pattern = "/" . $config->fields['requestlabel'] . ".*" . $config->fields['requestlabel'] . "/i";
 
@@ -149,8 +147,9 @@ JAVASCRIPT;
             if (preg_match_all($pattern, $mail->getContent(), $matches)) {
                 $string = $matches[0];
                 $useremail = str_replace($config->fields['requestlabel'], "", $string);
+                $useremail = str_replace(" ", "", $useremail); // remove possible spaces
                 $user = new User();
-                if ($user->getFromDBbyEmail($useremail[0])) {
+                if (isset($useremail[0]) && $user->getFromDBbyEmail($useremail[0])) {
                     $ticket->input['_users_id_requester'] = $user->fields['id'];
 
                     $mailgate = new MailCollector();

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -157,6 +157,8 @@ JAVASCRIPT;
                 $string = $matches[0];
                 $useremail = str_replace($config->fields['requestlabel'], "", $string);
                 $useremail = str_replace(" ", "", $useremail); // remove possible spaces
+                //remove not valid characters
+                $useremail = preg_replace("/[^a-zA-Z0-9@._-]/", "", $useremail);
                 $user = new User();
                 if (isset($useremail[0]) && $user->getFromDBbyEmail($useremail[0])) {
                     $ticket->input['_users_id_requester'] = $user->fields['id'];

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_YAGP_VERSION', '2.2.2-b.1');
+define('PLUGIN_YAGP_VERSION', '2.2.2');
 // Minimal GLPI version, inclusive
 define("PLUGIN_YAGP_MIN_GLPI", "10.0");
 // Maximum GLPI version, exclusive

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_YAGP_VERSION', '2.2.1');
+define('PLUGIN_YAGP_VERSION', '2.2.2-b.1');
 // Minimal GLPI version, inclusive
 define("PLUGIN_YAGP_MIN_GLPI", "10.0");
 // Maximum GLPI version, exclusive


### PR DESCRIPTION
Fixed mail detection
Allow intermediate spaces to avoid an error in generating the link to the email
![image](https://github.com/ticgal/yagp/assets/114425698/b58c4fd3-b419-4020-85aa-e82cedfa4aa9)
